### PR TITLE
hmint-902 change contract to mainnnet

### DIFF
--- a/src/config/contract.ts
+++ b/src/config/contract.ts
@@ -1,13 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const { NFTContractType, NetworkEnvironment, NetworkType, NetworkChain } = HyperMint;
-
 export default {
-    contractId: '35a7b61a-763b-446b-916a-8cf24b262477',
-    contractAddress: '0xaec2959723c9e662b3ca56e27b3c1136aabfdd80',
-    contractType: NFTContractType.ERC1155,
-    networkEnvironment: NetworkEnvironment.Testnet,
-    networkType: NetworkType.Ethereum,
-    networkChain: NetworkChain.Goerli,
+    contractId: 'ee20b68e-356c-4547-bac1-2ccee24a47cd',
     enableLogging: true
 };


### PR DESCRIPTION
- Uses mainnet contract to avoid issues with our new stale contract cleanup
- This will only fix storefront.hypermint.com but I can manually fix the demo domain once this is merged

View the contract here: https://app.hypermint.com/contracts/ee20b68e-356c-4547-bac1-2ccee24a47cd#general